### PR TITLE
Remove preconfigured event types from explore list

### DIFF
--- a/apps/web/app/api/events/list/route.ts
+++ b/apps/web/app/api/events/list/route.ts
@@ -91,6 +91,10 @@ const transformEvent = (event: Event) => ({
       event.dataset.catalog != null
         ? event.dataset.catalog.name
         : undefined,
+    fieldMetadata:
+      typeof event.dataset === "object" && event.dataset != null ? event.dataset.fieldMetadata : undefined,
+    displayConfig:
+      typeof event.dataset === "object" && event.dataset != null ? event.dataset.displayConfig : undefined,
   },
   data: event.data,
   location: event.location
@@ -99,6 +103,7 @@ const transformEvent = (event: Event) => ({
         latitude: event.location.latitude,
       }
     : null,
+  geocodingInfo: event.geocodingInfo,
   eventTimestamp: event.eventTimestamp,
   isValid: event.validationStatus === "valid",
 });

--- a/apps/web/lib/collections/datasets.ts
+++ b/apps/web/lib/collections/datasets.ts
@@ -549,6 +549,59 @@ const Datasets: CollectionConfig = {
         },
       ],
     },
+    // Display Field Configuration
+    {
+      name: "displayConfig",
+      type: "group",
+      admin: {
+        description: "Customize how events from this dataset are displayed in the UI",
+      },
+      fields: [
+        {
+          name: "primaryLabelField",
+          type: "text",
+          admin: {
+            description:
+              "Field path to use as the primary label/title (e.g., 'title', 'event_name'). Leave empty for automatic selection.",
+            placeholder: "Auto-detect from field metadata",
+          },
+        },
+        {
+          name: "displayFields",
+          type: "array",
+          admin: {
+            description: "Specify which fields to show in event lists. Leave empty for automatic selection.",
+          },
+          fields: [
+            {
+              name: "fieldPath",
+              type: "text",
+              required: true,
+              admin: {
+                description: "JSON path to field (e.g., 'description', 'location.city')",
+              },
+            },
+            {
+              name: "label",
+              type: "text",
+              admin: {
+                description: "Optional custom label for display (defaults to field name)",
+              },
+            },
+          ],
+        },
+        {
+          name: "maxDisplayFields",
+          type: "number",
+          min: 1,
+          max: 10,
+          defaultValue: 3,
+          admin: {
+            description: "Maximum number of fields to display in list views",
+          },
+        },
+      ],
+    },
   ],
 };
 

--- a/apps/web/lib/utils/event-display-formatter.ts
+++ b/apps/web/lib/utils/event-display-formatter.ts
@@ -1,0 +1,265 @@
+/**
+ * Event display formatter - transforms arbitrary event data into displayable format.
+ *
+ * Uses field metadata from dataset schemas to intelligently select and format
+ * fields for display without hardcoding specific field names.
+ *
+ * @module
+ * @category Utils
+ */
+
+interface FieldStatistics {
+  path: string;
+  occurrences: number;
+  occurrencePercent: number;
+  uniqueValues?: number;
+  typeDistribution?: Record<string, number>;
+  formats?: Record<string, number>;
+}
+
+interface EventDisplayInfo {
+  primaryLabel: string;
+  fields: Array<{ key: string; value: string }>;
+}
+
+interface DisplayConfig {
+  primaryLabelField?: string | null;
+  displayFields?: Array<{ fieldPath: string; label?: string | null }> | null;
+  maxDisplayFields?: number | null;
+}
+
+/**
+ * Gets the dominant type for a field from type distribution.
+ */
+const getDominantType = (typeDistribution: Record<string, number> | undefined): string | null => {
+  if (!typeDistribution) return null;
+
+  let maxCount = 0;
+  let dominantType: string | null = null;
+
+  for (const [type, count] of Object.entries(typeDistribution)) {
+    if (count > maxCount) {
+      maxCount = count;
+      dominantType = type;
+    }
+  }
+
+  return dominantType;
+};
+
+/**
+ * Scores a field for use as a primary label.
+ * Higher scores = better candidate for primary display.
+ */
+const scorePrimaryLabelField = (stats: FieldStatistics): number => {
+  let score = 0;
+
+  // High occurrence is critical
+  score += (stats.occurrencePercent ?? 0) * 2;
+
+  // String fields are preferred for labels
+  const dominantType = getDominantType(stats.typeDistribution);
+  if (dominantType === "string") {
+    score += 30;
+  }
+
+  // Fields with moderate uniqueness are good (not too generic, not too unique)
+  const uniqueRatio = (stats.uniqueValues ?? 0) / Math.max(stats.occurrences, 1);
+  if (uniqueRatio > 0.5 && uniqueRatio < 1.0) {
+    score += 20;
+  }
+
+  // Prefer top-level fields (lower depth)
+  score += (5 - stats.path.split(".").length) * 5;
+
+  // Boost common label field names
+  const fieldName = stats.path.toLowerCase();
+  if (fieldName.includes("title") || fieldName.includes("name")) {
+    score += 40;
+  } else if (fieldName.includes("subject") || fieldName.includes("heading")) {
+    score += 30;
+  } else if (fieldName.includes("label") || fieldName.includes("description")) {
+    score += 20;
+  }
+
+  return score;
+};
+
+/**
+ * Scores a field for inclusion in the display fields list.
+ */
+const scoreDisplayField = (stats: FieldStatistics): number => {
+  let score = 0;
+
+  // Occurrence percent is important
+  score += (stats.occurrencePercent ?? 0);
+
+  // Prefer primitive types (strings, numbers, booleans)
+  const dominantType = getDominantType(stats.typeDistribution);
+  if (dominantType === "string" || dominantType === "number" || dominantType === "boolean") {
+    score += 20;
+  }
+
+  // Prefer fields with special formats
+  if (stats.formats) {
+    if (stats.formats.date || stats.formats.dateTime) score += 15;
+    if (stats.formats.email) score += 10;
+    if (stats.formats.url) score += 10;
+  }
+
+  // Prefer top-level fields
+  score += (5 - stats.path.split(".").length) * 3;
+
+  return score;
+};
+
+/**
+ * Safely converts a value to a display string.
+ */
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    // Truncate long strings
+    return value.length > 100 ? value.substring(0, 97) + "..." : value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === "object") {
+    // For objects/arrays, try to show something useful
+    if (Array.isArray(value)) {
+      return `[${value.length} items]`;
+    }
+    return JSON.stringify(value).substring(0, 100);
+  }
+  return "";
+};
+
+/**
+ * Gets a nested value from an object using a path like "location.city".
+ */
+const getNestedValue = (obj: Record<string, unknown>, path: string): unknown => {
+  const parts = path.split(".");
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current && typeof current === "object" && !Array.isArray(current)) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+
+  return current;
+};
+
+/**
+ * Formats event data for display using field metadata and optional display configuration.
+ *
+ * @param eventData - The raw event data object
+ * @param fieldMetadata - Field statistics from the dataset schema
+ * @param eventId - Fallback event ID if no good label found
+ * @param displayConfig - Optional display configuration from dataset
+ * @param maxFields - Maximum number of fields to display (default: 3)
+ * @returns Structured display information
+ */
+export const formatEventForDisplay = (
+  eventData: Record<string, unknown>,
+  fieldMetadata: Record<string, FieldStatistics> | null | undefined,
+  eventId: string | number,
+  displayConfig?: DisplayConfig | null,
+  maxFields: number = 3
+): EventDisplayInfo => {
+  // Use configured max fields if available
+  const effectiveMaxFields = displayConfig?.maxDisplayFields ?? maxFields;
+
+  // If no metadata, show first few fields from the data
+  if (!fieldMetadata || Object.keys(fieldMetadata).length === 0) {
+    const entries = Object.entries(eventData).slice(0, effectiveMaxFields);
+    return {
+      primaryLabel: `Event ${eventId}`,
+      fields: entries.map(([key, value]) => ({
+        key,
+        value: formatValue(value),
+      })),
+    };
+  }
+
+  // Convert fieldMetadata to array and score each field
+  const fieldStats = Object.values(fieldMetadata);
+
+  // === PRIMARY LABEL SELECTION ===
+  let primaryLabel = `Event ${eventId}`;
+
+  // 1. Check if there's a configured primary label field
+  if (displayConfig?.primaryLabelField) {
+    const labelValue = getNestedValue(eventData, displayConfig.primaryLabelField);
+    const formatted = formatValue(labelValue);
+    if (formatted) {
+      primaryLabel = formatted;
+    }
+  } else {
+    // 2. Fall back to automatic selection
+    const labelCandidates = fieldStats
+      .filter((stats) => stats.occurrencePercent > 50) // At least 50% occurrence
+      .sort((a, b) => scorePrimaryLabelField(b) - scorePrimaryLabelField(a));
+
+    if (labelCandidates.length > 0 && labelCandidates[0]) {
+      const labelField = labelCandidates[0];
+      const labelValue = getNestedValue(eventData, labelField.path);
+      const formatted = formatValue(labelValue);
+      if (formatted) {
+        primaryLabel = formatted;
+      }
+    }
+  }
+
+  // === DISPLAY FIELDS SELECTION ===
+  let fields: Array<{ key: string; value: string }> = [];
+
+  // 1. Check if there are configured display fields
+  if (displayConfig?.displayFields && displayConfig.displayFields.length > 0) {
+    fields = displayConfig.displayFields
+      .map((fieldConfig) => {
+        const value = getNestedValue(eventData, fieldConfig.fieldPath);
+        const formatted = formatValue(value);
+        if (!formatted) return null;
+
+        return {
+          key: fieldConfig.label || fieldConfig.fieldPath,
+          value: formatted,
+        };
+      })
+      .filter((field): field is { key: string; value: string } => field !== null)
+      .slice(0, effectiveMaxFields);
+  } else {
+    // 2. Fall back to automatic selection
+    const displayCandidates = fieldStats
+      .filter((stats) => stats.occurrencePercent > 30) // At least 30% occurrence
+      .sort((a, b) => scoreDisplayField(b) - scoreDisplayField(a))
+      .slice(0, effectiveMaxFields);
+
+    fields = displayCandidates
+      .map((stats) => {
+        const value = getNestedValue(eventData, stats.path);
+        const formatted = formatValue(value);
+        if (!formatted) return null;
+
+        return {
+          key: stats.path,
+          value: formatted,
+        };
+      })
+      .filter((field): field is { key: string; value: string } => field !== null);
+  }
+
+  return {
+    primaryLabel,
+    fields,
+  };
+};

--- a/apps/web/tests/integration/api/events-list-display-config.test.ts
+++ b/apps/web/tests/integration/api/events-list-display-config.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Integration tests for events list API with display configuration.
+ *
+ * Tests that the events list API correctly includes fieldMetadata and
+ * displayConfig, and that custom display configurations are properly
+ * returned to the client.
+ *
+ * @module
+ * @category Integration Tests
+ */
+import { NextRequest } from "next/server";
+
+import { GET } from "../../../app/api/events/list/route";
+import { createIntegrationTestEnvironment } from "../../setup/test-environment-builder";
+
+describe("Events List API - Display Configuration", () => {
+  let testEnv: Awaited<ReturnType<typeof createIntegrationTestEnvironment>>;
+
+  afterEach(async () => {
+    if (testEnv) {
+      await testEnv.cleanup();
+    }
+  });
+
+  it("should include fieldMetadata in API response", async () => {
+    testEnv = await createIntegrationTestEnvironment();
+
+    const { payload, user } = testEnv;
+
+    // Create a catalog and dataset with field metadata
+    const catalog = await payload.create({
+      collection: "catalogs",
+      data: {
+        name: "Test Catalog",
+        slug: "test-catalog",
+        isPublic: true,
+        createdBy: user.id,
+      },
+      user,
+    });
+
+    const dataset = await payload.create({
+      collection: "datasets",
+      data: {
+        name: "Test Dataset",
+        slug: "test-dataset",
+        language: "eng",
+        catalog: catalog.id,
+        isPublic: true,
+        fieldMetadata: {
+          title: {
+            path: "title",
+            occurrences: 100,
+            occurrencePercent: 100,
+            uniqueValues: 95,
+            typeDistribution: { string: 100 },
+          },
+          description: {
+            path: "description",
+            occurrences: 90,
+            occurrencePercent: 90,
+            uniqueValues: 85,
+            typeDistribution: { string: 90 },
+          },
+        },
+      },
+      user,
+    });
+
+    // Create an event
+    await payload.create({
+      collection: "events",
+      data: {
+        dataset: dataset.id,
+        data: {
+          title: "Test Event",
+          description: "Test Description",
+        },
+        uniqueId: "test-event-1",
+        validationStatus: "valid",
+        _status: "published",
+      },
+      user,
+    });
+
+    // Call the API
+    const url = new URL("http://localhost:3000/api/events/list");
+    const request = new NextRequest(url);
+
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.events).toBeDefined();
+    expect(data.events.length).toBeGreaterThan(0);
+
+    // Check that fieldMetadata is included
+    const event = data.events[0];
+    expect(event?.dataset?.fieldMetadata).toBeDefined();
+    expect(event?.dataset?.fieldMetadata?.title).toBeDefined();
+    expect(event?.dataset?.fieldMetadata?.title?.path).toBe("title");
+    expect(event?.dataset?.fieldMetadata?.description).toBeDefined();
+  });
+
+  it("should include displayConfig in API response", async () => {
+    testEnv = await createIntegrationTestEnvironment();
+
+    const { payload, user } = testEnv;
+
+    // Create a catalog
+    const catalog = await payload.create({
+      collection: "catalogs",
+      data: {
+        name: "Test Catalog",
+        slug: "test-catalog-config",
+        isPublic: true,
+        createdBy: user.id,
+      },
+      user,
+    });
+
+    // Create a dataset with custom display config
+    const dataset = await payload.create({
+      collection: "datasets",
+      data: {
+        name: "Test Dataset with Config",
+        slug: "test-dataset-config",
+        language: "eng",
+        catalog: catalog.id,
+        isPublic: true,
+        fieldMetadata: {
+          event_name: {
+            path: "event_name",
+            occurrences: 100,
+            occurrencePercent: 100,
+            uniqueValues: 95,
+            typeDistribution: { string: 100 },
+          },
+          venue: {
+            path: "venue",
+            occurrences: 100,
+            occurrencePercent: 100,
+            uniqueValues: 40,
+            typeDistribution: { string: 100 },
+          },
+          price: {
+            path: "price",
+            occurrences: 80,
+            occurrencePercent: 80,
+            uniqueValues: 20,
+            typeDistribution: { number: 80 },
+          },
+        },
+        displayConfig: {
+          primaryLabelField: "event_name",
+          displayFields: [
+            { fieldPath: "venue", label: "Location" },
+            { fieldPath: "price", label: "Ticket Price" },
+          ],
+          maxDisplayFields: 2,
+        },
+      },
+      user,
+    });
+
+    // Create an event
+    await payload.create({
+      collection: "events",
+      data: {
+        dataset: dataset.id,
+        data: {
+          event_name: "Rock Concert",
+          venue: "Madison Square Garden",
+          price: 75,
+        },
+        uniqueId: "test-event-2",
+        validationStatus: "valid",
+        _status: "published",
+      },
+      user,
+    });
+
+    // Call the API
+    const url = new URL("http://localhost:3000/api/events/list");
+    const request = new NextRequest(url);
+
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.events).toBeDefined();
+
+    // Find our event
+    const event = data.events.find((e: { data: { event_name?: string } }) => e.data?.event_name === "Rock Concert");
+    expect(event).toBeDefined();
+
+    // Check that displayConfig is included
+    expect(event?.dataset?.displayConfig).toBeDefined();
+    expect(event?.dataset?.displayConfig?.primaryLabelField).toBe("event_name");
+    expect(event?.dataset?.displayConfig?.displayFields).toHaveLength(2);
+    expect(event?.dataset?.displayConfig?.displayFields?.[0]?.fieldPath).toBe("venue");
+    expect(event?.dataset?.displayConfig?.displayFields?.[0]?.label).toBe("Location");
+    expect(event?.dataset?.displayConfig?.maxDisplayFields).toBe(2);
+  });
+
+  it("should work with events that have no display config", async () => {
+    testEnv = await createIntegrationTestEnvironment();
+
+    const { payload, user } = testEnv;
+
+    // Create a catalog
+    const catalog = await payload.create({
+      collection: "catalogs",
+      data: {
+        name: "Test Catalog No Config",
+        slug: "test-catalog-no-config",
+        isPublic: true,
+        createdBy: user.id,
+      },
+      user,
+    });
+
+    // Create a dataset WITHOUT display config
+    const dataset = await payload.create({
+      collection: "datasets",
+      data: {
+        name: "Test Dataset No Config",
+        slug: "test-dataset-no-config",
+        language: "eng",
+        catalog: catalog.id,
+        isPublic: true,
+        fieldMetadata: {
+          station_id: {
+            path: "station_id",
+            occurrences: 100,
+            occurrencePercent: 100,
+            uniqueValues: 50,
+            typeDistribution: { string: 100 },
+          },
+        },
+      },
+      user,
+    });
+
+    // Create an event
+    await payload.create({
+      collection: "events",
+      data: {
+        dataset: dataset.id,
+        data: {
+          station_id: "STATION-001",
+          measurement: "temperature",
+          value: 23.5,
+        },
+        uniqueId: "test-event-3",
+        validationStatus: "valid",
+        _status: "published",
+      },
+      user,
+    });
+
+    // Call the API
+    const url = new URL("http://localhost:3000/api/events/list");
+    const request = new NextRequest(url);
+
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.events).toBeDefined();
+
+    // Should still return fieldMetadata even without displayConfig
+    const event = data.events.find((e: { data: { station_id?: string } }) => e.data?.station_id === "STATION-001");
+    expect(event).toBeDefined();
+    expect(event?.dataset?.fieldMetadata).toBeDefined();
+    // displayConfig should be undefined or null
+    expect(event?.dataset?.displayConfig).toBeUndefined();
+  });
+
+  it("should include geocodingInfo in API response", async () => {
+    testEnv = await createIntegrationTestEnvironment();
+
+    const { payload, user } = testEnv;
+
+    // Create a catalog
+    const catalog = await payload.create({
+      collection: "catalogs",
+      data: {
+        name: "Test Catalog Geocoding",
+        slug: "test-catalog-geocoding",
+        isPublic: true,
+        createdBy: user.id,
+      },
+      user,
+    });
+
+    // Create a dataset
+    const dataset = await payload.create({
+      collection: "datasets",
+      data: {
+        name: "Test Dataset Geocoding",
+        slug: "test-dataset-geocoding",
+        language: "eng",
+        catalog: catalog.id,
+        isPublic: true,
+      },
+      user,
+    });
+
+    // Create an event with geocoding info
+    await payload.create({
+      collection: "events",
+      data: {
+        dataset: dataset.id,
+        data: {
+          name: "Event with Location",
+        },
+        location: {
+          latitude: 40.7128,
+          longitude: -74.006,
+        },
+        geocodingInfo: {
+          normalizedAddress: "New York, NY, USA",
+          originalAddress: "NYC",
+        },
+        uniqueId: "test-event-4",
+        validationStatus: "valid",
+        _status: "published",
+      },
+      user,
+    });
+
+    // Call the API
+    const url = new URL("http://localhost:3000/api/events/list");
+    const request = new NextRequest(url);
+
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+
+    // Find our event
+    const event = data.events.find(
+      (e: { geocodingInfo?: { normalizedAddress?: string } }) =>
+        e.geocodingInfo?.normalizedAddress === "New York, NY, USA"
+    );
+    expect(event).toBeDefined();
+    expect(event?.geocodingInfo?.normalizedAddress).toBe("New York, NY, USA");
+    expect(event?.geocodingInfo?.originalAddress).toBe("NYC");
+    expect(event?.location?.latitude).toBe(40.7128);
+    expect(event?.location?.longitude).toBe(-74.006);
+  });
+});

--- a/apps/web/tests/unit/utils/event-display-formatter.test.ts
+++ b/apps/web/tests/unit/utils/event-display-formatter.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Unit tests for event display formatter.
+ *
+ * Tests intelligent field selection and formatting for event display
+ * based on field metadata and custom display configurations.
+ *
+ * @module
+ * @category Tests
+ */
+import { describe, expect, it } from "vitest";
+
+import { formatEventForDisplay } from "../../../lib/utils/event-display-formatter";
+
+describe("Event Display Formatter", () => {
+  describe("with no field metadata", () => {
+    it("should return first 3 fields when no metadata available", () => {
+      const eventData = {
+        field1: "value1",
+        field2: "value2",
+        field3: "value3",
+        field4: "value4",
+      };
+
+      const result = formatEventForDisplay(eventData, null, 123);
+
+      expect(result.primaryLabel).toBe("Event 123");
+      expect(result.fields).toHaveLength(3);
+      expect(result.fields[0]).toEqual({ key: "field1", value: "value1" });
+      expect(result.fields[1]).toEqual({ key: "field2", value: "value2" });
+      expect(result.fields[2]).toEqual({ key: "field3", value: "value3" });
+    });
+
+    it("should respect maxFields parameter", () => {
+      const eventData = {
+        field1: "value1",
+        field2: "value2",
+        field3: "value3",
+      };
+
+      const result = formatEventForDisplay(eventData, null, 123, null, 2);
+
+      expect(result.fields).toHaveLength(2);
+    });
+
+    it("should handle empty event data", () => {
+      const result = formatEventForDisplay({}, null, 456);
+
+      expect(result.primaryLabel).toBe("Event 456");
+      expect(result.fields).toHaveLength(0);
+    });
+  });
+
+  describe("with field metadata (automatic selection)", () => {
+    it("should select field with 'title' in name as primary label", () => {
+      const eventData = {
+        title: "My Event Title",
+        description: "Event description",
+        date: "2024-01-15",
+      };
+
+      const fieldMetadata = {
+        title: {
+          path: "title",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 95,
+          typeDistribution: { string: 100 },
+        },
+        description: {
+          path: "description",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 90,
+          typeDistribution: { string: 100 },
+        },
+        date: {
+          path: "date",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 50,
+          typeDistribution: { string: 100 },
+          formats: { date: 100 },
+        },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      expect(result.primaryLabel).toBe("My Event Title");
+    });
+
+    it("should select field with 'name' as fallback for primary label", () => {
+      const eventData = {
+        event_name: "Conference 2024",
+        venue: "Main Hall",
+      };
+
+      const fieldMetadata = {
+        event_name: {
+          path: "event_name",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 90,
+          typeDistribution: { string: 100 },
+        },
+        venue: {
+          path: "venue",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 40,
+          typeDistribution: { string: 100 },
+        },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      expect(result.primaryLabel).toBe("Conference 2024");
+    });
+
+    it("should select most appropriate fields for display based on scoring", () => {
+      const eventData = {
+        id: "123",
+        title: "Event",
+        description: "Long description",
+        venue: "Stadium",
+        price: 50,
+        internal_id: "abc123",
+      };
+
+      const fieldMetadata = {
+        id: {
+          path: "id",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 100,
+          typeDistribution: { string: 100 },
+        },
+        title: {
+          path: "title",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 95,
+          typeDistribution: { string: 100 },
+        },
+        description: {
+          path: "description",
+          occurrences: 90,
+          occurrencePercent: 90,
+          uniqueValues: 85,
+          typeDistribution: { string: 90 },
+        },
+        venue: {
+          path: "venue",
+          occurrences: 80,
+          occurrencePercent: 80,
+          uniqueValues: 30,
+          typeDistribution: { string: 80 },
+        },
+        price: {
+          path: "price",
+          occurrences: 75,
+          occurrencePercent: 75,
+          uniqueValues: 20,
+          typeDistribution: { number: 75 },
+        },
+        internal_id: {
+          path: "internal_id",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 100,
+          typeDistribution: { string: 100 },
+        },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      // Should prioritize fields with good occurrence and meaningful data
+      expect(result.fields.length).toBeLessThanOrEqual(3);
+      // Should select high-occurrence fields (all have >30% occurrence threshold)
+      expect(result.fields.length).toBeGreaterThan(0);
+      // All fields should have values
+      result.fields.forEach((field) => {
+        expect(field.value).toBeTruthy();
+      });
+    });
+
+    it("should filter out fields with low occurrence percentage", () => {
+      const eventData = {
+        title: "Event",
+        rare_field: "value",
+      };
+
+      const fieldMetadata = {
+        title: {
+          path: "title",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 95,
+          typeDistribution: { string: 100 },
+        },
+        rare_field: {
+          path: "rare_field",
+          occurrences: 20,
+          occurrencePercent: 20, // Below 30% threshold
+          uniqueValues: 15,
+          typeDistribution: { string: 20 },
+        },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      // rare_field should not appear in display fields
+      expect(result.fields.every((f) => f.key !== "rare_field")).toBe(true);
+    });
+  });
+
+  describe("with display configuration", () => {
+    it("should use configured primary label field", () => {
+      const eventData = {
+        title: "Should not use this",
+        event_name: "Should use this",
+        description: "Some description",
+      };
+
+      const fieldMetadata = {
+        title: {
+          path: "title",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 95,
+          typeDistribution: { string: 100 },
+        },
+        event_name: {
+          path: "event_name",
+          occurrences: 100,
+          occurrencePercent: 100,
+          uniqueValues: 90,
+          typeDistribution: { string: 100 },
+        },
+      };
+
+      const displayConfig = {
+        primaryLabelField: "event_name",
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123, displayConfig);
+
+      expect(result.primaryLabel).toBe("Should use this");
+    });
+
+    it("should use configured display fields in order", () => {
+      const eventData = {
+        field1: "value1",
+        field2: "value2",
+        field3: "value3",
+        field4: "value4",
+      };
+
+      const fieldMetadata = {
+        field1: { path: "field1", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+        field2: { path: "field2", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+        field3: { path: "field3", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+        field4: { path: "field4", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+      };
+
+      const displayConfig = {
+        displayFields: [
+          { fieldPath: "field3", label: "Custom Label 3" },
+          { fieldPath: "field1", label: "Custom Label 1" },
+        ],
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123, displayConfig);
+
+      expect(result.fields).toHaveLength(2);
+      expect(result.fields[0]).toEqual({ key: "Custom Label 3", value: "value3" });
+      expect(result.fields[1]).toEqual({ key: "Custom Label 1", value: "value1" });
+    });
+
+    it("should use field path as label when custom label not provided", () => {
+      const eventData = {
+        myField: "myValue",
+      };
+
+      const fieldMetadata = {
+        myField: { path: "myField", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+      };
+
+      const displayConfig = {
+        displayFields: [{ fieldPath: "myField", label: null }],
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123, displayConfig);
+
+      expect(result.fields[0]?.key).toBe("myField");
+    });
+
+    it("should respect maxDisplayFields from config", () => {
+      const eventData = {
+        field1: "value1",
+        field2: "value2",
+        field3: "value3",
+        field4: "value4",
+      };
+
+      const fieldMetadata = {
+        field1: { path: "field1", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+        field2: { path: "field2", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+        field3: { path: "field3", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+        field4: { path: "field4", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+      };
+
+      const displayConfig = {
+        maxDisplayFields: 2,
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123, displayConfig);
+
+      expect(result.fields.length).toBeLessThanOrEqual(2);
+    });
+
+    it("should handle nested field paths", () => {
+      const eventData = {
+        location: {
+          city: "New York",
+          country: "USA",
+        },
+        event: {
+          name: "Conference",
+        },
+      };
+
+      const fieldMetadata = {
+        "location.city": {
+          path: "location.city",
+          occurrences: 100,
+          occurrencePercent: 100,
+          typeDistribution: { string: 100 },
+        },
+      };
+
+      const displayConfig = {
+        displayFields: [{ fieldPath: "location.city", label: "City" }],
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123, displayConfig);
+
+      expect(result.fields[0]).toEqual({ key: "City", value: "New York" });
+    });
+
+    it("should skip fields with missing values", () => {
+      const eventData = {
+        field1: "value1",
+        field2: null,
+        field3: "",
+      };
+
+      const fieldMetadata = {
+        field1: { path: "field1", occurrences: 100, occurrencePercent: 100, typeDistribution: { string: 100 } },
+        field2: { path: "field2", occurrences: 50, occurrencePercent: 50, typeDistribution: { string: 50 } },
+      };
+
+      const displayConfig = {
+        displayFields: [
+          { fieldPath: "field1", label: "Field 1" },
+          { fieldPath: "field2", label: "Field 2" },
+          { fieldPath: "field3", label: "Field 3" },
+        ],
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123, displayConfig);
+
+      // Only field1 should be included (field2 is null, field3 is empty)
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0]?.key).toBe("Field 1");
+    });
+  });
+
+  describe("value formatting", () => {
+    it("should format numbers correctly", () => {
+      const eventData = { price: 42.5 };
+      const fieldMetadata = {
+        price: { path: "price", occurrences: 100, occurrencePercent: 100, typeDistribution: { number: 100 } },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      expect(result.fields.some((f) => f.value === "42.5")).toBe(true);
+    });
+
+    it("should format booleans correctly", () => {
+      const eventData = { active: true };
+      const fieldMetadata = {
+        active: { path: "active", occurrences: 100, occurrencePercent: 100, typeDistribution: { boolean: 100 } },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      expect(result.fields.some((f) => f.value === "true")).toBe(true);
+    });
+
+    it("should truncate long strings", () => {
+      const longString = "a".repeat(150);
+      const eventData = { description: longString };
+      const fieldMetadata = {
+        description: {
+          path: "description",
+          occurrences: 100,
+          occurrencePercent: 100,
+          typeDistribution: { string: 100 },
+        },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      const descField = result.fields.find((f) => f.key === "description");
+      expect(descField?.value.length).toBeLessThanOrEqual(100);
+      expect(descField?.value).toContain("...");
+    });
+
+    it("should handle arrays by showing item count", () => {
+      const eventData = { tags: ["tag1", "tag2", "tag3"] };
+      const fieldMetadata = {
+        tags: { path: "tags", occurrences: 100, occurrencePercent: 100, typeDistribution: { array: 100 } },
+      };
+
+      const result = formatEventForDisplay(eventData, fieldMetadata, 123);
+
+      const tagsField = result.fields.find((f) => f.key === "tags");
+      expect(tagsField?.value).toBe("[3 items]");
+    });
+  });
+});


### PR DESCRIPTION
…ection

Remove hardcoded event field assumptions (title, description, etc.) and implement a flexible system for displaying arbitrary event data.

Changes:
- Add intelligent field selection algorithm based on metadata scoring
- Support custom display configuration per dataset (primaryLabelField, displayFields, maxDisplayFields)
- Create event display formatter utility with automatic fallbacks
- Update all event displays (explore, list, detail pages) to use formatter
- Include fieldMetadata and displayConfig in events API response
- Add comprehensive unit tests (17 test cases)
- Add integration tests (5 test cases) for API response structure

The system prioritizes configured fields, falls back to automatic selection based on occurrence percentage and field characteristics, and handles nested field paths (e.g., "location.city").