### PR TITLE
test(e2e): wait for /api/auth/login not /api/users/login

### DIFF
--- a/apps/web/tests/e2e/flows/ingest-wizard.test.ts
+++ b/apps/web/tests/e2e/flows/ingest-wizard.test.ts
@@ -140,7 +140,7 @@ test.describe("Import Wizard - Authentication", () => {
     await importPage.loginButton.click();
 
     // Wait for login API response
-    await page.waitForResponse((resp) => resp.url().includes("/api/users/login"), { timeout: 5000 });
+    await page.waitForResponse((resp) => resp.url().includes("/api/auth/login"), { timeout: 5000 });
 
     // Should still be on the auth step — sign in heading should remain visible
     const signInHeading = page.getByRole("heading", { name: /sign in to continue/i });

--- a/apps/web/tests/e2e/pages/ingest.page.ts
+++ b/apps/web/tests/e2e/pages/ingest.page.ts
@@ -193,7 +193,7 @@ export class IngestPage {
 
     // Click login button and wait for API response
     const [response] = await Promise.all([
-      this.page.waitForResponse((resp) => resp.url().includes("/api/users/login"), { timeout: 5000 }),
+      this.page.waitForResponse((resp) => resp.url().includes("/api/auth/login"), { timeout: 5000 }),
       this.loginButton.click(),
     ]);
 


### PR DESCRIPTION
## Summary

- Fixes 3 of 10 persistent E2E failures on `main` — the two ingest-wizard login tests (and the upstream `IngestPage.login` helper used by other flows).
- Root cause: frontend login was refactored to the `/api/auth/login` wrapper (6e17416c, e35e50ac) for audit coverage; the UI waits in `tests/e2e/pages/ingest.page.ts` and `tests/e2e/flows/ingest-wizard.test.ts` still targeted the old `/api/users/login` path, so `waitForResponse` timed out.

## Remaining on-main failures (not addressed)

CI on `main` has been red since at least 2026-04-16 with 10 E2E failures per run. This PR fixes the clear stale-test case; the others still need investigation:

- `explore-basic.test.ts` — `events-list-skeleton` not visible within 3s. Test-id exists; likely media-query / loading-phase timing.
- `explore-filtering.test.ts` (4 tests) — `waitForTimelineReady` never resolves. Likely temporal-histogram never renders for the seeded fixture.
- `explore-map.test.ts` — same timeline dependency as above.
- `ingest-wizard.test.ts:315` (multi-sheet Excel) — `setRequiredFieldTarget` select value never matches.
- `scheduled-ingest-edit.test.ts:123` — schedule paused with `high-duplicates`; duplicate-detection regression or threshold too tight for e2e fixture.

These need live debug (traces in artifacts `playwright-results.zip`) to localize. Worth a follow-up PR.

## Test plan

- [ ] CI passes `ingest-wizard.test.ts` login tests on this branch
- [ ] `make check-ai` clean for the two touched files (verified locally)